### PR TITLE
Move dependency back to upstream fuzzytime.

### DIFF
--- a/followedTask.go
+++ b/followedTask.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dmwilcox/fuzzytime"
+	"github.com/bcampbell/fuzzytime"
 	nomadApi "github.com/hashicorp/nomad/api"
 )
 


### PR DESCRIPTION
@bcampbell graciously merged my fuzzytime PR almost immediately but I didn't notice and we have been running on my fork (which I'd like to clean-up).  This PR will put us back on the upstream for fuzzytime.  The most recent commit on fuzzytime is mine from work on nomad_follower anyway so no changes are expected.